### PR TITLE
draw.creatures.js Unselect bug fix

### DIFF
--- a/experiments/mp-game-6/draw.creatures.js
+++ b/experiments/mp-game-6/draw.creatures.js
@@ -107,7 +107,7 @@ function drawTestCreature(stim, creatureInd, scale, roundProps){
         if (roundProps.selected_test_stim.includes(id)) {
             // Remove Previously Marked Creature
             unmarkAsSpecies(id);
-            roundProps.selected_test_stim = roundProps.selected_test_stim.slice(
+            roundProps.selected_test_stim.splice(
                 roundProps.selected_test_stim.indexOf(id),
                 1
             );


### PR DESCRIPTION
I am a summer intern working with Jesse and Noah and I found a bug in the draw.creatures.js file. This bug was in mp-game-6 in the testing phase, and caused all previous selections to be deleted whenever a user deselected a creature. This is the fix for that bug. 